### PR TITLE
Improve documentation with detailed README in English and Japanese

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,208 @@
 # tmux-tabicon
-[tmux-tabicon-theme](https://github.com/mocaffy/tmux-tabicon-theme)
-![screenshot](https://user-images.githubusercontent.com/45122432/218329999-735b3a4f-23fc-4aea-95af-ca732cdfc03b.png)
-![screenshot](https://user-images.githubusercontent.com/45122432/218330413-3e45b472-dfaf-40bb-b7b4-38cd9e42d16d.png)
 
+A powerful plugin for customizing tmux window tabs (window-status) with colors, icons, and advanced formatting.
 
-## これはなに
-Tmux のタブ (window-status) の高度な装飾を可能にするプラグインです。  
+[![screenshot](https://user-images.githubusercontent.com/45122432/218329999-735b3a4f-23fc-4aea-95af-ca732cdfc03b.png)](https://user-images.githubusercontent.com/45122432/218329999-735b3a4f-23fc-4aea-95af-ca732cdfc03b.png)
+[![screenshot](https://user-images.githubusercontent.com/45122432/218330413-3e45b472-dfaf-40bb-b7b4-38cd9e42d16d.png)](https://user-images.githubusercontent.com/45122432/218330413-3e45b472-dfaf-40bb-b7b4-38cd9e42d16d.png)
 
-## インストール
-tmux.conf
-```
+## What is tmux-tabicon?
+
+tmux-tabicon is a plugin that enables advanced customization of tmux window tabs (window-status). It allows you to:
+
+- Apply automatic or conditional colors to tabs
+- Add icons to tabs
+- Customize the appearance of active and inactive tabs
+- Apply special formatting to first and last tabs
+- Create session-specific themes
+
+## Installation
+
+### Prerequisites
+
+- [tmux](https://github.com/tmux/tmux) (version 2.9 or later recommended)
+- [TPM](https://github.com/tmux-plugins/tpm) (Tmux Plugin Manager)
+
+### Using TPM (recommended)
+
+Add the following to your `~/.tmux.conf`:
+
+```bash
+# Set the themes directory (create this directory if it doesn't exist)
+set -g @tmux-tabicon-themes-dir "~/.config/tmux/tabicon-themes"
+
+# Add the plugin
 set -g @plugin 'mocaffy/tmux-tabicon'
-run '~/.config/tmux/plugins/tpm/tpm'
+
+# Initialize TMUX plugin manager (keep this line at the very bottom of tmux.conf)
+run '~/.tmux/plugins/tpm/tpm'
 ```
+
+Then press `prefix` + <kbd>I</kbd> to install the plugin.
+
+### Manual Installation
+
+Clone the repository:
+
+```bash
+git clone https://github.com/mocaffy/tmux-tabicon.git ~/.tmux/plugins/tmux-tabicon
+```
+
+Add the following to your `~/.tmux.conf`:
+
+```bash
+# Set the themes directory (create this directory if it doesn't exist)
+set -g @tmux-tabicon-themes-dir "~/.config/tmux/tabicon-themes"
+
+# Source the plugin
+run-shell ~/.tmux/plugins/tmux-tabicon/tabicon.tmux
+```
+
+## How It Works
+
+tmux-tabicon works by:
+
+1. Loading configuration files that define colors, icons, and formatting
+2. Generating tmux format strings based on these configurations
+3. Applying these format strings to window-status-format and window-status-current-format
+4. Refreshing the display when tmux events occur (new window, pane exit, etc.)
+
+The plugin uses tmux hooks to automatically update the tab appearance when changes occur in your tmux session.
+
+## Configuration
+
+### Theme Directory
+
+Create a themes directory and set it in your tmux.conf:
+
+```bash
+set -g @tmux-tabicon-themes-dir "~/.config/tmux/tabicon-themes"
+```
+
+### Configuration Files
+
+tmux-tabicon uses the following configuration files:
+
+1. **default.conf** - Built-in default settings (don't modify this)
+2. **normal.conf** - Your custom settings that apply to all sessions (create this in your themes directory)
+3. **[session-name].conf** - Session-specific settings (optional, create in your themes directory)
+
+### Creating Your Theme
+
+Create a `normal.conf` file in your themes directory:
+
+```bash
+mkdir -p ~/.config/tmux/tabicon-themes
+touch ~/.config/tmux/tabicon-themes/normal.conf
+```
+
+### Configuration Options
+
+Here are the key configuration options you can set in your theme files:
+
+#### Colors
+
+```bash
+# Automatic colors (rotated through tabs)
+auto_colors=("#9a348e" "#da627d" "#fca17d" "#86bbd8" "#06969A" "#33658a")
+
+# Conditional colors (applied based on window name or other conditions)
+manual_colors=("?#{==:#W,[tmux]},#0000ff")
+```
+
+#### Icons
+
+```bash
+# Automatic icons (rotated through tabs)
+auto_icons=("●")
+
+# Conditional icons (applied based on window name or other conditions)
+manual_icons=("?#{==:#W,[tmux]},")
+```
+
+#### Normal Tab Styling
+
+```bash
+# Window title format
+tab_title="#W"
+
+# Formatting for tab beginning
+tab_before_first=" "      # For the first tab
+tab_before="#[fg=#222233]▏"  # For other tabs
+
+# Style settings
+style_tab=""              # Base style
+style_tab_icon="#[fg=#C]"  # Icon style (#C is replaced with color)
+style_tab_title="#[fg=#ffffff]"  # Title style
+
+# Formatting for tab end
+tab_after=" "            # For most tabs
+tab_after_last=" "       # For the last tab
+```
+
+#### Active Tab Styling
+
+```bash
+# Active window title format
+tab_active_title="#W"
+
+# Formatting for active tab beginning
+tab_active_before_first=" "
+tab_active_before="#[fg=#222233]▏"
+
+# Style settings for active tab
+style_tab_active="#[bg=#C]#[fg=#ffffff]"  # Base style
+style_tab_active_icon=""  # Icon style
+style_tab_active_title="" # Title style
+
+# Formatting for active tab end
+tab_active_after=" "
+tab_active_after_last=" "
+```
+
+#### Separator
+
+```bash
+# Character between tabs
+tab_separator=""
+```
+
+## Advanced Usage
+
+### Conditional Formatting
+
+You can use tmux's conditional formatting to change colors or icons based on window properties:
+
+```bash
+# Make SSH windows red
+manual_colors=("?#{==:#{pane_current_command},ssh},#ff0000")
+
+# Add special icon for vim windows
+manual_icons=("?#{==:#{pane_current_command},vim},")
+```
+
+### Session-Specific Themes
+
+Create a configuration file named after your session:
+
+```bash
+# For a session named "dev"
+touch ~/.config/tmux/tabicon-themes/dev.conf
+```
+
+This configuration will only apply when you're in the "dev" session.
+
+## Troubleshooting
+
+If your tabs aren't updating properly:
+
+1. Press `prefix` + <kbd>r</kbd> to manually refresh the tabs
+2. Check that your themes directory is set correctly
+3. Verify your configuration files have the correct syntax
+
+## Related Projects
+
+- [tmux-tabicon-theme](https://github.com/mocaffy/tmux-tabicon-theme) - Pre-made themes for tmux-tabicon
+
+## License
+
+[MIT](LICENSE)

--- a/README_ja.md
+++ b/README_ja.md
@@ -1,0 +1,208 @@
+# tmux-tabicon
+
+tmuxのウィンドウタブ（window-status）を色、アイコン、高度なフォーマットでカスタマイズするための強力なプラグインです。
+
+[![スクリーンショット](https://user-images.githubusercontent.com/45122432/218329999-735b3a4f-23fc-4aea-95af-ca732cdfc03b.png)](https://user-images.githubusercontent.com/45122432/218329999-735b3a4f-23fc-4aea-95af-ca732cdfc03b.png)
+[![スクリーンショット](https://user-images.githubusercontent.com/45122432/218330413-3e45b472-dfaf-40bb-b7b4-38cd9e42d16d.png)](https://user-images.githubusercontent.com/45122432/218330413-3e45b472-dfaf-40bb-b7b4-38cd9e42d16d.png)
+
+## tmux-tabiconとは？
+
+tmux-tabiconは、tmuxのウィンドウタブ（window-status）の高度なカスタマイズを可能にするプラグインです。以下のことができます：
+
+- タブに自動または条件付きの色を適用する
+- タブにアイコンを追加する
+- アクティブなタブと非アクティブなタブの外観をカスタマイズする
+- 最初と最後のタブに特別なフォーマットを適用する
+- セッション固有のテーマを作成する
+
+## インストール
+
+### 前提条件
+
+- [tmux](https://github.com/tmux/tmux) (バージョン2.9以降を推奨)
+- [TPM](https://github.com/tmux-plugins/tpm) (Tmux Plugin Manager)
+
+### TPMを使用する方法（推奨）
+
+`~/.tmux.conf`に以下を追加します：
+
+```bash
+# テーマディレクトリを設定（このディレクトリが存在しない場合は作成してください）
+set -g @tmux-tabicon-themes-dir "~/.config/tmux/tabicon-themes"
+
+# プラグインを追加
+set -g @plugin 'mocaffy/tmux-tabicon'
+
+# TMUXプラグインマネージャを初期化（tmux.confの最後に記述してください）
+run '~/.tmux/plugins/tpm/tpm'
+```
+
+その後、`prefix` + <kbd>I</kbd>を押してプラグインをインストールします。
+
+### 手動インストール
+
+リポジトリをクローンします：
+
+```bash
+git clone https://github.com/mocaffy/tmux-tabicon.git ~/.tmux/plugins/tmux-tabicon
+```
+
+`~/.tmux.conf`に以下を追加します：
+
+```bash
+# テーマディレクトリを設定（このディレクトリが存在しない場合は作成してください）
+set -g @tmux-tabicon-themes-dir "~/.config/tmux/tabicon-themes"
+
+# プラグインを読み込む
+run-shell ~/.tmux/plugins/tmux-tabicon/tabicon.tmux
+```
+
+## 動作の仕組み
+
+tmux-tabiconは以下のように動作します：
+
+1. 色、アイコン、フォーマットを定義する設定ファイルを読み込む
+2. これらの設定に基づいてtmuxフォーマット文字列を生成する
+3. これらのフォーマット文字列をwindow-status-formatとwindow-status-current-formatに適用する
+4. tmuxイベント（新しいウィンドウ、ペインの終了など）が発生したときに表示を更新する
+
+このプラグインはtmuxフックを使用して、tmuxセッションで変更が発生したときにタブの外観を自動的に更新します。
+
+## 設定
+
+### テーマディレクトリ
+
+テーマディレクトリを作成し、tmux.confで設定します：
+
+```bash
+set -g @tmux-tabicon-themes-dir "~/.config/tmux/tabicon-themes"
+```
+
+### 設定ファイル
+
+tmux-tabiconは以下の設定ファイルを使用します：
+
+1. **default.conf** - 組み込みのデフォルト設定（変更しないでください）
+2. **normal.conf** - すべてのセッションに適用されるカスタム設定（テーマディレクトリに作成します）
+3. **[セッション名].conf** - セッション固有の設定（オプション、テーマディレクトリに作成します）
+
+### テーマの作成
+
+テーマディレクトリに`normal.conf`ファイルを作成します：
+
+```bash
+mkdir -p ~/.config/tmux/tabicon-themes
+touch ~/.config/tmux/tabicon-themes/normal.conf
+```
+
+### 設定オプション
+
+テーマファイルで設定できる主なオプションは以下の通りです：
+
+#### 色
+
+```bash
+# 自動色（タブを通じてローテーションされる）
+auto_colors=("#9a348e" "#da627d" "#fca17d" "#86bbd8" "#06969A" "#33658a")
+
+# 条件付き色（ウィンドウ名やその他の条件に基づいて適用される）
+manual_colors=("?#{==:#W,[tmux]},#0000ff")
+```
+
+#### アイコン
+
+```bash
+# 自動アイコン（タブを通じてローテーションされる）
+auto_icons=("●")
+
+# 条件付きアイコン（ウィンドウ名やその他の条件に基づいて適用される）
+manual_icons=("?#{==:#W,[tmux]},")
+```
+
+#### 通常タブのスタイル
+
+```bash
+# ウィンドウタイトルのフォーマット
+tab_title="#W"
+
+# タブの先頭部分のフォーマット
+tab_before_first=" "      # 最初のタブ用
+tab_before="#[fg=#222233]▏"  # その他のタブ用
+
+# スタイル設定
+style_tab=""              # 基本スタイル
+style_tab_icon="#[fg=#C]"  # アイコンスタイル（#Cは色に置き換えられる）
+style_tab_title="#[fg=#ffffff]"  # タイトルスタイル
+
+# タブの末尾部分のフォーマット
+tab_after=" "            # ほとんどのタブ用
+tab_after_last=" "       # 最後のタブ用
+```
+
+#### アクティブタブのスタイル
+
+```bash
+# アクティブウィンドウタイトルのフォーマット
+tab_active_title="#W"
+
+# アクティブタブの先頭部分のフォーマット
+tab_active_before_first=" "
+tab_active_before="#[fg=#222233]▏"
+
+# アクティブタブのスタイル設定
+style_tab_active="#[bg=#C]#[fg=#ffffff]"  # 基本スタイル
+style_tab_active_icon=""  # アイコンスタイル
+style_tab_active_title="" # タイトルスタイル
+
+# アクティブタブの末尾部分のフォーマット
+tab_active_after=" "
+tab_active_after_last=" "
+```
+
+#### セパレータ
+
+```bash
+# タブ間の文字
+tab_separator=""
+```
+
+## 高度な使用法
+
+### 条件付きフォーマット
+
+tmuxの条件付きフォーマットを使用して、ウィンドウのプロパティに基づいて色やアイコンを変更できます：
+
+```bash
+# SSHウィンドウを赤色にする
+manual_colors=("?#{==:#{pane_current_command},ssh},#ff0000")
+
+# vimウィンドウに特別なアイコンを追加する
+manual_icons=("?#{==:#{pane_current_command},vim},")
+```
+
+### セッション固有のテーマ
+
+セッション名に基づいた設定ファイルを作成します：
+
+```bash
+# "dev"という名前のセッション用
+touch ~/.config/tmux/tabicon-themes/dev.conf
+```
+
+この設定は、「dev」セッションにいる場合にのみ適用されます。
+
+## トラブルシューティング
+
+タブが正しく更新されない場合：
+
+1. `prefix` + <kbd>r</kbd>を押してタブを手動で更新する
+2. テーマディレクトリが正しく設定されていることを確認する
+3. 設定ファイルの構文が正しいことを確認する
+
+## 関連プロジェクト
+
+- [tmux-tabicon-theme](https://github.com/mocaffy/tmux-tabicon-theme) - tmux-tabicon用の既製テーマ
+
+## ライセンス
+
+[MIT](LICENSE)


### PR DESCRIPTION
This PR improves the documentation of the tmux-tabicon plugin by:

1. Expanding the English README.md with comprehensive information about:
   - What the plugin does
   - Installation instructions
   - How the plugin works
   - Configuration options with examples
   - Advanced usage examples
   - Troubleshooting tips

2. Adding a Japanese README_ja.md with the same detailed information for Japanese-speaking users.

These documentation improvements will make it easier for users to understand, install, and customize the plugin.